### PR TITLE
Criado primeiro endpoint para a API com dados mockados

### DIFF
--- a/skeleton/src/Controller/ApiController.php
+++ b/skeleton/src/Controller/ApiController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\GoogleSheetsService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route("/api/v1.0", name: "api_v1.0")]
+class ApiController extends AbstractController
+{
+    private GoogleSheetsService $googleSheetsService;
+
+    public function __construct(GoogleSheetsService $googleSheetsService)
+    {
+        $this->googleSheetsService = $googleSheetsService;
+    }
+
+    #[Route("/scales/get-conflicts/{sheetId}", name:'get_conflicts')]
+    public function getConflicts(string $sheetId): JsonResponse
+    {
+        // $result = $this->googleSheetsService->getSheetData($sheetId, $sheetName);
+        // Compute conflicts
+
+        $mockedResult = [
+            "conflicts" => [
+                "date" => "2021-01-01",
+                "scales" => [
+                    [
+                        "scaleName" => "Período Integral",
+                        "conflicts" => [
+                            [
+                                "id" => 1,
+                                "date" => "2021-01-01",
+                                "status" => "unsolved",
+                                "firefighters" => [
+                                    [
+                                        "id" => 1,
+                                        "name" => "BC Roberto",
+                                    ],
+                                    [
+                                        "id" => 2,
+                                        "name" => "BC Ana",
+                                    ],
+                                    [
+                                        "id" => 3,
+                                        "name" => "BC João",
+                                    ]
+                                ]
+                            ],
+                        ]
+                    ],
+                    [
+                        "scaleName" => "Período Noturno",
+                        "conflicts" => [
+                            [
+                                "id" => 2,
+                                "date" => "2021-01-01",
+                                "status" => "unsolved",
+                                "firefighters" => [
+                                    [
+                                        "id" => 4,
+                                        "name" => "BC Léo",
+                                    ],
+                                    [
+                                        "id" => 5,
+                                        "name" => "BC Aline",
+                                    ],
+                                    [
+                                        "id" => 6,
+                                        "name" => "BC Rafa",
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        return $this->json($mockedResult);
+
+    }
+}


### PR DESCRIPTION
Relacionado ao issue https://github.com/paulopmt1/cbmsc-booker/issues/19

Estou adicionando um retorno mock para podermos destravar a implementação do frontend para exibir os conflitos. Falta ainda implementarmos toda rotina de gerar o conflito a partir da leitura da planilha no Google.

Questões para definir:
- Se vamos usar a planilha de destino como banco de dados, como permitir desfazer ação de gestão de conflitos?
- Como logar as ações de conflitos realizadas? Precisamos mesmo logar isso agora?

Com esse retorno da API, será possível renderizar a tela [descrita nesse issue](https://github.com/paulopmt1/cbmsc-booker/issues/18).



### Como testar?

Acesse http://localhost:8084/api/v1.0/scales/get-conflicts/spreadsheetID1234 e veja o retorno mockado pronto para ser usado pelo React:

<img width="787" height="1229" alt="image" src="https://github.com/user-attachments/assets/7e085b20-8aff-407e-a059-7779871bbd75" />

