### PR TITLE
Usando a API do Google para ler planilha de respostas

### DIFF
--- a/skeleton/src/Controller/SyncController.php
+++ b/skeleton/src/Controller/SyncController.php
@@ -36,7 +36,8 @@ class SyncController extends AbstractController
             try 
             {
                 $credentialsPath = $_ENV['GOOGLE_AUTH_CONFIG'];
-                $dadosPlanilhaBrutos = $googleSheetsService->getSheetData($sheetId, "A1:C100");
+                $googleSheetsService->configureClient($credentialsPath);
+                $dadosPlanilhaBrutos = $googleSheetsService->getSheetData($sheetId, "A2:AI100");
                 $bombeiros = $writeSheetsService->convertePlanilhaParaObjetosDeBombeiros($dadosPlanilhaBrutos);
                 $dadosPlanilhaProcessados = $writeSheetsService->converterBombeirosParaPlanilha($bombeiros);
 


### PR DESCRIPTION
Referente ao issue https://github.com/paulopmt1/cbmsc-booker/issues/25

### O que estamos mudando aqui?

Com a leitura usando o link público, nossa aplicação estava menos segura e exigia que os soldados usassem a permissão "qualquer pessoa com o link" em vez de compartilhar a planilha com o email da aplicação, que eles já sabem fazer.

A abordagem anterior foi necessária pois foi rápida de implementar para um primeiro momento, mas agora podemos dar um passo a mais.
