### PR TITLE
Refactor: extract integral quota decomposition to partial shifts

### DIFF
--- a/skeleton/src/Entity/Turno.php
+++ b/skeleton/src/Entity/Turno.php
@@ -7,8 +7,9 @@ use App\Constants\CbmscConstants;
 class Turno {
     private int $dia;
     private string $turno;
+    private bool $turno_integral_decomposto;
 
-    public function __construct(int $dia, string $turno) {
+    public function __construct(int $dia, string $turno, bool $turno_integral_decomposto = false) {
         $turnosValidos = CbmscConstants::getTurnosValidos();
         
         if (!in_array($turno, $turnosValidos, true)) {
@@ -23,6 +24,7 @@ class Turno {
         
         $this->dia = $dia;
         $this->turno = $turno;
+        $this->turno_integral_decomposto = $turno_integral_decomposto;
     }
 
     public function getDia(): int {
@@ -31,5 +33,9 @@ class Turno {
 
     public function getTurno(): string {
         return $this->turno;
+    }
+
+    public function getETurnoIntegralDecomposto() {
+        return $this->turno_integral_decomposto;
     }
 }

--- a/skeleton/tests/Service/DistribuicaoTurnosTest.php
+++ b/skeleton/tests/Service/DistribuicaoTurnosTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Constants\CbmscConstants;
+use App\Entity\Bombeiro;
+use App\Entity\Disponibilidade;
+use App\Entity\Turno;
+use App\Service\CalculadorDeAntiguidade;
+use App\Service\CalculadorDePontos;
+use PHPUnit\Framework\TestCase;
+
+class DistribuicaoTurnosTest extends TestCase
+{
+    private CalculadorDeAntiguidade $calculadorDeAntiguidade;
+    private CalculadorDePontos $calculador;
+
+    protected function setUp(): void
+    {
+        // Mock do CalculadorDeAntiguidade
+        $this->calculadorDeAntiguidade = $this->createMock(CalculadorDeAntiguidade::class);
+        $this->calculadorDeAntiguidade->method('getAntiguidade')
+            ->willReturn(50); // Retorna uma antiguidade padrão de 50
+
+        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade);
+    }
+
+    /**
+     * Caso algum dia tenhamos 3 bombeiros para fazer serviço integral, iremos
+     * decompor um serviço integral em 1 diurno
+     * 
+     * Isso é importante, pois permite asseguramos que teremos todas as vagas 
+     * preenchidas.
+     * 
+     * TODO: Talvez precisamos suportar casos onde o bombeiro pode apenas integral.
+     * Por exemplo, pode não ser viável um serviço não integral para um bombeiro que vem de outra cidade
+     */
+    public function testDecompoeServicoIntegralEmDiurno(): void
+    {
+        $dia = 1;
+
+        // Cria 3 bombeiros com disponibilidades diferentes
+        $bombeiro1 = new Bombeiro('Bombeiro 1', '11111111111', true);
+        $bombeiro1->adicionarDisponibilidade(new Disponibilidade($dia, CbmscConstants::TURNO_INTEGRAL));
+
+        $bombeiro2 = new Bombeiro('Bombeiro 2', '22222222222', true);
+        $bombeiro2->adicionarDisponibilidade(new Disponibilidade($dia, CbmscConstants::TURNO_INTEGRAL));;
+
+        $bombeiro3 = new Bombeiro('Bombeiro 3', '33333333333', true);
+        $bombeiro3->adicionarDisponibilidade(new Disponibilidade($dia, CbmscConstants::TURNO_INTEGRAL));
+
+        $this->calculador->adicionarBombeiro($bombeiro1);
+        $this->calculador->adicionarBombeiro($bombeiro2);
+        $this->calculador->adicionarBombeiro($bombeiro3);
+
+        $resultado = $this->calculador->distribuirTurnosParaMes(60);
+
+        $this->assertIsArray($resultado);
+        $this->assertIsArray($resultado[$dia]['INTEGRAL']);
+        $this->assertEquals(2, count($resultado[$dia]['INTEGRAL']));
+        
+        $this->assertIsArray($resultado[$dia]['DIURNO']);
+        $this->assertEquals(1, count($resultado[$dia]['DIURNO']));
+    }
+
+
+    // TODO: Criar teste para novo método private obtemHorasDistribuidas
+}
+


### PR DESCRIPTION
## Summary
- Extracts `decomporCotasIntegraisEmTurnoParcial` method from `distribuirTurnosParaDia` for better code organization
- Adds loop logic to keep assigning bombeiros until the required `horasPorDia` is reached
- Handles both diurno and noturno shifts when decomposing integral quotas to fill remaining hours

## Test plan
- [ ] Run existing unit tests to ensure no regressions
- [ ] Verify shift distribution correctly fills days with partial shifts when integral quotas are insufficient
- [ ] Test edge cases where no bombeiros with integral availability remain