### PR TITLE
Refactor: receive Google credentials as JSON env var instead of file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,9 @@ RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/opcache.ini \
 # Copy built application from builder
 COPY --from=builder /var/www/html /var/www/html
 
+# Create minimal .env file for Symfony (required for cache:clear during composer install)
+RUN echo "APP_ENV=prod" > /var/www/html/.env
+
 # Copy Apache config
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ O ambiente de desenvolvimento é feito com Docker.
 ### Fazendo setup com docker
 Tenha o Docker e docker-compose instalado e rodando.
 
-1. Em sua máquina, abra o terminal e rode o comando: `docker compose up -d`
-2. Agora entre no container da aplicação: `docker exec -it cbmsc_booker_web bash`
-3. Instale as dependências do projeto (rodando dentro do container): `composer install`
-4. Instale os pacotes frontend: `yarn install`
-5. Rode a aplicação node do ambiente `dev` com: `npm run dev-server`
+1. Copie o arquivo de credenciais do aplicativo do google dentro da pasta `secrets` que não é versionada
+
+2. Popule a variável de ambiente GOOGLE_CREDENTIALS_JSON com esse comando (a partir do host): `export GOOGLE_CREDENTIALS_JSON=$(cat secrets/cbmsc-booker-credentials.json)`
+
+3. Em sua máquina, abra o terminal e rode o comando: `docker compose up -d`
+4. Agora entre no container da aplicação: `docker exec -it cbmsc_booker_web bash`
+5. Instale as dependências do projeto (rodando dentro do container): `composer install`
+6. Instale os pacotes frontend: `yarn install`
+7. Rode a aplicação node do ambiente `dev` com: `npm run dev-server`
 
 ### Acesse a aplicação
 
@@ -56,10 +60,10 @@ A planilha de origem deve:
 A planilha de destino deve:
 - Estar com o email do robô tendo permissão de edição (planilha-rob@cbmsc-booker.iam.gserviceaccount.com)
 
-O arquivo `.env` deve possuir o path para o arquivo `cbmsc-booker-credentials.json`. Aqui um exemplo de path:
+A variável de ambiente `GOOGLE_CREDENTIALS_JSON` deve conter o conteúdo JSON das credenciais do Google Service Account. Exemplo:
 
-```
-GOOGLE_AUTH_CONFIG=/var/www/html/config/cbmsc-booker-credentials.json
+```bash
+export GOOGLE_CREDENTIALS_JSON='{"type":"service_account","project_id":"...","private_key":"..."}'
 ```
 
 ---
@@ -71,21 +75,9 @@ O deploy em produção utiliza Docker com configurações otimizadas.
 ### Pré-requisitos
 
 - Docker e docker-compose instalados no servidor
-- Arquivo `cbmsc-booker-credentials.json` (credenciais do Google Service Account)
+- Credenciais JSON do Google Service Account
 
-### Passo 1: Configurar credenciais do Google
-
-Copie o arquivo de credenciais para a pasta `secrets/` do projeto:
-
-```bash
-mkdir -p ./secrets
-cp cbmsc-booker-credentials.json ./secrets/
-chmod 600 ./secrets/cbmsc-booker-credentials.json
-```
-
-> **Nota:** A pasta `secrets/` está no `.gitignore` e não será commitada.
-
-### Passo 2: Configurar variáveis de ambiente
+### Passo 1: Configurar variáveis de ambiente
 
 Defina as variáveis de ambiente necessárias:
 
@@ -95,11 +87,16 @@ export MYSQL_DATABASE="cbmsc_booker"
 export MYSQL_USER="cbmsc_user"
 export MYSQL_PASSWORD="sua-senha-segura"
 export APP_SECRET="$(openssl rand -hex 32)"
+
+# Credenciais do Google (conteúdo JSON do arquivo de service account)
+export GOOGLE_CREDENTIALS_JSON='{"type":"service_account","project_id":"cbmsc-booker","private_key_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","client_email":"planilha-rob@cbmsc-booker.iam.gserviceaccount.com","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"..."}'
 ```
+
+> **Dica:** Você pode carregar o JSON de um arquivo com: `export GOOGLE_CREDENTIALS_JSON=$(cat cbmsc-booker-credentials.json)`
 
 > **Dica:** Para persistir as variáveis, adicione-as ao arquivo `/etc/environment` ou crie um script de inicialização.
 
-### Passo 3: Executar o deploy
+### Passo 2: Executar o deploy
 
 ```bash
 ./deploy.sh

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,8 +10,6 @@ services:
       target: production
     ports:
       - "5001:80"
-    volumes:
-      - ${GOOGLE_CREDENTIALS_PATH:-./secrets/cbmsc-booker-credentials.json}:/var/www/html/config/cbmsc-booker-credentials.json:ro
     depends_on:
       db:
         condition: service_healthy
@@ -23,7 +21,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-cbmsc_user}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE:-cbmsc_booker}
-      - GOOGLE_AUTH_CONFIG=/var/www/html/config/cbmsc-booker-credentials.json
+      - GOOGLE_CREDENTIALS_JSON=${GOOGLE_CREDENTIALS_JSON}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - MYSQL_PASSWORD=mypassword
       - MYSQL_DATABASE=mydatabase
       - APP_RUNTIME_ENV=dev
+      - GOOGLE_CREDENTIALS_JSON=${GOOGLE_CREDENTIALS_JSON:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/skeleton/config/packages/google_apiclient.yaml
+++ b/skeleton/config/packages/google_apiclient.yaml
@@ -8,4 +8,4 @@ services:
             - [setClientId, ['%env(GOOGLE_CLIENT_ID)%']]
             - [setClientSecret, ['%env(GOOGLE_CLIENT_SECRET)%']]
             # Authentication with "OAuth 2.0" or "Service account" using JSON
-            - [setAuthConfig, ['%env(resolve:GOOGLE_AUTH_CONFIG)%']]
+            - [setAuthConfig, ['%env(json:GOOGLE_CREDENTIALS_JSON)%']]

--- a/skeleton/config/services.yaml
+++ b/skeleton/config/services.yaml
@@ -4,12 +4,12 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    google_auth_config: '%env(GOOGLE_AUTH_CONFIG)%'
+    google_credentials_json: '%env(GOOGLE_CREDENTIALS_JSON)%'
 
 services:
     App\Service\GoogleSheetsService:
         arguments:
-            $credentialsPath: '%google_auth_config%'
+            $credentialsJson: '%google_credentials_json%'
 
     App\Service\ConversorPlanilhasBombeiro:
         autowire: true

--- a/skeleton/src/Service/GoogleSheetsService.php
+++ b/skeleton/src/Service/GoogleSheetsService.php
@@ -12,10 +12,15 @@ class GoogleSheetsService
     private ?Sheets $sheetsService = null;
 
     public function __construct(
-        private readonly string $credentialsPath
+        private readonly string $credentialsJson
     ) {
+        $credentials = json_decode($credentialsJson, true);
+        if ($credentials === null) {
+            throw new Exception("Credenciais do Google inválidas: JSON malformado");
+        }
+
         $client = new Client();
-        $client->setAuthConfig($credentialsPath);
+        $client->setAuthConfig($credentials);
         $client->addScope(Sheets::SPREADSHEETS);
         $this->sheetsService = new Sheets($client);
     }


### PR DESCRIPTION
## Summary

- Replace `GOOGLE_AUTH_CONFIG` file path with `GOOGLE_CREDENTIALS_JSON` environment variable containing the actual JSON credentials data
- Simplifies deployment by eliminating the need to mount credential files into containers
- Update `GoogleSheetsService` to decode JSON credentials string
- Use Symfony's `json:` env processor in `google_apiclient.yaml`

## Changes

- `skeleton/src/Service/GoogleSheetsService.php` - Accept JSON string and decode it
- `skeleton/config/services.yaml` - Use new `GOOGLE_CREDENTIALS_JSON` env var
- `skeleton/config/packages/google_apiclient.yaml` - Use `%env(json:GOOGLE_CREDENTIALS_JSON)%`
- `docker-compose.prod.yml` - Remove volume mount, use env var directly
- `docker-compose.yml` - Add env var for development
- `README.md` - Update setup and deployment instructions
- `.gitignore` - Add secrets folder
- `Dockerfile` - Add minimal .env for Symfony cache:clear

## Test plan

- [ ] Set `GOOGLE_CREDENTIALS_JSON` with valid credentials JSON
- [ ] Run `docker compose up -d` and verify the app starts
- [ ] Test Google Sheets integration works correctly