### PR TITLE
Refactor CPF_DO_QUERUBIN to use environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /secrets
+skeleton/.phpunit.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ RUN pecl install xdebug \
 # Use development PHP settings
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
+# Disable OPcache in development
+RUN printf "opcache.enable=0\nopcache.enable_cli=0\n" > /usr/local/etc/php/conf.d/zz-opcache-dev.ini
+
 # Development environment
 ENV APP_ENV=dev
 ENV APP_DEBUG=1
@@ -66,9 +69,6 @@ FROM base AS builder
 # Copy application files
 COPY skeleton/ /var/www/html/
 
-# Create minimal .env file for Symfony (required for composer install scripts)
-RUN echo "APP_ENV=prod" > /var/www/html/.env
-
 # Install PHP dependencies (production only)
 RUN composer install --no-dev --optimize-autoloader --no-interaction --no-progress
 
@@ -82,6 +82,9 @@ RUN if [ -f "package.json" ]; then \
 # PRODUCTION TARGET
 # ============================================================
 FROM base AS production
+
+# Create minimal .env file for Symfony (required for composer install scripts)
+RUN echo "APP_ENV=prod" > /var/www/html/.env
 
 # Use production PHP settings
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/README.md
+++ b/README.md
@@ -82,11 +82,8 @@ O deploy em produção utiliza Docker com configurações otimizadas.
 Defina as variáveis de ambiente necessárias:
 
 ```bash
-export MYSQL_ROOT_PASSWORD="sua-senha-root-segura"
-export MYSQL_DATABASE="cbmsc_booker"
-export MYSQL_USER="cbmsc_user"
-export MYSQL_PASSWORD="sua-senha-segura"
 export APP_SECRET="$(openssl rand -hex 32)"
+export CPF_DO_QUERUBIN=000000000 (somente números do CPF do Querubin)
 
 # Credenciais do Google (conteúdo JSON do arquivo de service account)
 export GOOGLE_CREDENTIALS_JSON='{"type":"service_account","project_id":"cbmsc-booker","private_key_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","client_email":"planilha-rob@cbmsc-booker.iam.gserviceaccount.com","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"..."}'

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,8 +9,12 @@ NC='\033[0m' # No Color
 
 echo -e "${GREEN}=== CBMSC Booker Production Deployment ===${NC}"
 
+# Set default MySQL credentials
+export MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root}"
+export MYSQL_PASSWORD="${MYSQL_PASSWORD:-root}"
+
 # Check required environment variables
-REQUIRED_VARS=("MYSQL_ROOT_PASSWORD" "MYSQL_PASSWORD" "APP_SECRET")
+REQUIRED_VARS=("APP_SECRET" "GOOGLE_CREDENTIALS_JSON" "CPF_DO_QUERUBIN")
 MISSING_VARS=()
 
 for var in "${REQUIRED_VARS[@]}"; do
@@ -25,28 +29,11 @@ if [ ${#MISSING_VARS[@]} -ne 0 ]; then
         echo -e "  - $var"
     done
     echo ""
-    echo "Please set these variables before running the deployment:"
+    echo "Este é o padrão de variáveis de ambiente para o deploy:"
     echo ""
-    echo "  export MYSQL_ROOT_PASSWORD=\"your-secure-root-password\""
-    echo "  export MYSQL_PASSWORD=\"your-secure-password\""
     echo "  export APP_SECRET=\"\$(openssl rand -hex 32)\""
-    echo ""
-    echo "Optional variables (with defaults):"
-    echo "  export MYSQL_DATABASE=\"cbmsc_booker\""
-    echo "  export MYSQL_USER=\"cbmsc_user\""
-    echo "  export GOOGLE_CREDENTIALS_PATH=\"/opt/secrets/cbmsc-booker-credentials.json\""
-    exit 1
-fi
-
-# Check if Google credentials file exists
-CREDS_PATH="${GOOGLE_CREDENTIALS_PATH:-./secrets/cbmsc-booker-credentials.json}"
-if [ ! -f "$CREDS_PATH" ]; then
-    echo -e "${RED}Error: Google credentials file not found at: $CREDS_PATH${NC}"
-    echo ""
-    echo "Please place the credentials file:"
-    echo "  mkdir -p ./secrets"
-    echo "  cp cbmsc-booker-credentials.json ./secrets/"
-    echo "  chmod 600 ./secrets/cbmsc-booker-credentials.json"
+    echo "  export GOOGLE_CREDENTIALS_JSON=\"'{"type":"service_account","project_id":"cbmsc-book...\"
+    echo "  export CPF_DO_QUERUBIN=\"000000000\" # (somente números do CPF do Querubin)"
     exit 1
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,12 @@ services:
       - db
     environment:
       - MYSQL_HOST=db
-      - MYSQL_USER=myuser
-      - MYSQL_PASSWORD=mypassword
-      - MYSQL_DATABASE=mydatabase
+      - MYSQL_USER=${MYSQL_USER:-cbmsc_user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-root}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-cbmsc_booker}
       - APP_RUNTIME_ENV=dev
       - GOOGLE_CREDENTIALS_JSON=${GOOGLE_CREDENTIALS_JSON:-}
+      - CPF_DO_QUERUBIN=${CPF_DO_QUERUBIN:-000000000}
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -33,10 +34,10 @@ services:
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=rootpassword
-      - MYSQL_DATABASE=mydatabase
-      - MYSQL_USER=myuser
-      - MYSQL_PASSWORD=mypassword
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-cbmsc_booker}
+      - MYSQL_USER=${MYSQL_USER:-cbmsc_user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-root}
     volumes:
       - mysql_data:/var/lib/mysql
 

--- a/skeleton/config/services.yaml
+++ b/skeleton/config/services.yaml
@@ -5,11 +5,16 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     google_credentials_json: '%env(GOOGLE_CREDENTIALS_JSON)%'
+    cpf_do_querubin: '%env(int:CPF_DO_QUERUBIN)%'
 
 services:
     App\Service\GoogleSheetsService:
         arguments:
             $credentialsJson: '%google_credentials_json%'
+    
+    App\Service\CalculadorDePontos:
+        arguments:
+            $cpfDoQuerubin: '%cpf_do_querubin%'
 
     App\Service\ConversorPlanilhasBombeiro:
         autowire: true

--- a/skeleton/src/Constants/CbmscConstants.php
+++ b/skeleton/src/Constants/CbmscConstants.php
@@ -12,7 +12,9 @@ class CbmscConstants {
     public const CIDADE_CACADOR = "Caçador";
     
     // CPFs especiais
-    public const CPF_DO_QUERUBIN = 10010010001; // CPF do Querubin
+    public static function getCpfDoQuerubin(): int {
+        return (int) ($_ENV['CPF_DO_QUERUBIN'] ?? 10010010001);
+    }
 
     // Colunas da planilha de respostas
     public const PLANILHA_HORARIOS_COLUNA_NOME = 1; // B (coluna 0 (A) é a data da resposta)

--- a/skeleton/src/Constants/CbmscConstants.php
+++ b/skeleton/src/Constants/CbmscConstants.php
@@ -10,11 +10,6 @@ class CbmscConstants {
     public const CIDADE_FRAIBURGO = "Fraiburgo";
     public const CIDADE_VIDEIRA = "Videira";
     public const CIDADE_CACADOR = "Caçador";
-    
-    // CPFs especiais
-    public static function getCpfDoQuerubin(): int {
-        return (int) ($_ENV['CPF_DO_QUERUBIN'] ?? 10010010001);
-    }
 
     // Colunas da planilha de respostas
     public const PLANILHA_HORARIOS_COLUNA_NOME = 1; // B (coluna 0 (A) é a data da resposta)

--- a/skeleton/src/Controller/SyncController.php
+++ b/skeleton/src/Controller/SyncController.php
@@ -8,6 +8,7 @@ use App\Service\CalculadorDePontos;
 use App\Service\GoogleSheetsService;
 use App\Service\ConversorPlanilhasBombeiro;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -19,7 +20,8 @@ class SyncController extends AbstractController
         Request $request,
         GoogleSheetsService $googleSheetsService,
         ConversorPlanilhasBombeiro $conversorPlanilhasBombeiro,
-        CalculadorDeAntiguidade $calculadorDeAntiguidade
+        CalculadorDeAntiguidade $calculadorDeAntiguidade,
+        ParameterBagInterface $parameterBag
     ): Response {
         
         if ($request->isMethod('POST'))
@@ -124,7 +126,8 @@ class SyncController extends AbstractController
                 // Convert cotasPorDia to hours (1 cota = 24 hours)
                 $horasPorDia = $cotasPorDiaFloat * 24;
 
-                $servico = new CalculadorDePontos($calculadorDeAntiguidade);
+                $cpfDoQuerubin = $parameterBag->get('cpf_do_querubin');
+                $servico = new CalculadorDePontos($calculadorDeAntiguidade, $cpfDoQuerubin);
                 foreach ($bombeiros as $bombeiro) {
                     $servico->adicionarBombeiro($bombeiro);
                 }

--- a/skeleton/src/Service/CalculadorDePontos.php
+++ b/skeleton/src/Service/CalculadorDePontos.php
@@ -11,7 +11,8 @@ class CalculadorDePontos {
 
     
     public function __construct(
-        private readonly CalculadorDeAntiguidade $calculadorDeAntiguidade
+        private readonly CalculadorDeAntiguidade $calculadorDeAntiguidade,
+        private readonly int $cpfDoQuerubin
     ) {
     }
 
@@ -75,7 +76,8 @@ class CalculadorDePontos {
             if ($zerarPontuacao) {
                 $bombeiro->setPontuacao(0);
 
-                if (intval($bombeiro->getCpf()) === CbmscConstants::getCpfDoQuerubin() ) {
+
+                if (intval($bombeiro->getCpf()) === $this->cpfDoQuerubin) {
                     $bombeiro->setPontuacao(CbmscConstants::PONTUACAO_QUERUBIN);
                 }
 

--- a/skeleton/src/Service/CalculadorDePontos.php
+++ b/skeleton/src/Service/CalculadorDePontos.php
@@ -75,8 +75,7 @@ class CalculadorDePontos {
             if ($zerarPontuacao) {
                 $bombeiro->setPontuacao(0);
 
-                // TODO: Melhorar essa tratativa
-                if ( $bombeiro->getNome() == 'BC CHEROBIN ' || intval($bombeiro->getCpf()) === CbmscConstants::CPF_DO_QUERUBIN ) {
+                if (intval($bombeiro->getCpf()) === CbmscConstants::getCpfDoQuerubin() ) {
                     $bombeiro->setPontuacao(CbmscConstants::PONTUACAO_QUERUBIN);
                 }
 

--- a/skeleton/tests/Service/CalculadorDePontosTest.php
+++ b/skeleton/tests/Service/CalculadorDePontosTest.php
@@ -72,7 +72,7 @@ class CalculadorDePontosTest extends TestCase
      */
     public function testDistribuirTurnosParaMesComQuerubim(): void
     {
-        $querubim = new Bombeiro('BC CHEROBIN ', strval(CbmscConstants::CPF_DO_QUERUBIN), false);
+        $querubim = new Bombeiro('BC CHEROBIN ', strval(CbmscConstants::getCpfDoQuerubin()), false);
         $querubim->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);
         $querubim->adicionarDisponibilidade(new Disponibilidade(1, CbmscConstants::TURNO_INTEGRAL));
         $querubim->adicionarDisponibilidade(new Disponibilidade(2, CbmscConstants::TURNO_INTEGRAL));
@@ -316,7 +316,7 @@ class CalculadorDePontosTest extends TestCase
     public function testDistribuirTurnosParaMesCombinacaoComplexa(): void
     {
         // Querubim com carteira
-        $querubim = new Bombeiro('BC CHEROBIN ', strval(CbmscConstants::CPF_DO_QUERUBIN), true);
+        $querubim = new Bombeiro('BC CHEROBIN ', strval(CbmscConstants::getCpfDoQuerubin()), true);
         $querubim->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);
         for ($dia = 1; $dia <= 5; $dia++) {
             $querubim->adicionarDisponibilidade(new Disponibilidade($dia, CbmscConstants::TURNO_INTEGRAL));

--- a/skeleton/tests/Service/CalculadorDePontosTest.php
+++ b/skeleton/tests/Service/CalculadorDePontosTest.php
@@ -22,7 +22,7 @@ class CalculadorDePontosTest extends TestCase
         $this->calculadorDeAntiguidade->method('getAntiguidade')
             ->willReturn(50); // Retorna uma antiguidade padrão de 50
 
-        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade);
+        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade, 10010010001);
     }
 
     /**
@@ -72,7 +72,7 @@ class CalculadorDePontosTest extends TestCase
      */
     public function testDistribuirTurnosParaMesComQuerubim(): void
     {
-        $querubim = new Bombeiro('BC CHEROBIN ', strval(CbmscConstants::getCpfDoQuerubin()), false);
+        $querubim = new Bombeiro('BC CHEROBIN ', strval(10010010001), false);
         $querubim->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);
         $querubim->adicionarDisponibilidade(new Disponibilidade(1, CbmscConstants::TURNO_INTEGRAL));
         $querubim->adicionarDisponibilidade(new Disponibilidade(2, CbmscConstants::TURNO_INTEGRAL));
@@ -316,7 +316,7 @@ class CalculadorDePontosTest extends TestCase
     public function testDistribuirTurnosParaMesCombinacaoComplexa(): void
     {
         // Querubim com carteira
-        $querubim = new Bombeiro('BC CHEROBIN ', strval(CbmscConstants::getCpfDoQuerubin()), true);
+        $querubim = new Bombeiro('BC CHEROBIN ', strval(10010010001), true);
         $querubim->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);
         for ($dia = 1; $dia <= 5; $dia++) {
             $querubim->adicionarDisponibilidade(new Disponibilidade($dia, CbmscConstants::TURNO_INTEGRAL));
@@ -563,7 +563,7 @@ class CalculadorDePontosTest extends TestCase
     public function testLimiteCotasIntegraisDiferentesHoras(): void
     {
         // Teste com 24 horas (1 cota) - limite = floor(24/24) = 1
-        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade);
+        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade, 10010010001);
         for ($i = 1; $i <= 3; $i++) {
             $bombeiro = new Bombeiro("Bombeiro Integral $i", str_pad((string)$i, 11, '0', STR_PAD_LEFT), false);
             $bombeiro->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);
@@ -577,7 +577,7 @@ class CalculadorDePontosTest extends TestCase
         $this->assertEquals(1, $cotasIntegrais24h, 'Com 24 horas, deve ter no máximo 1 cota integral');
 
         // Teste com 48 horas (2 cotas) - limite = floor(48/24) = 2
-        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade);
+        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade, 10010010001);
         for ($i = 1; $i <= 5; $i++) {
             $bombeiro = new Bombeiro("Bombeiro Integral $i", str_pad((string)$i, 11, '0', STR_PAD_LEFT), false);
             $bombeiro->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);
@@ -591,7 +591,7 @@ class CalculadorDePontosTest extends TestCase
         $this->assertEquals(2, $cotasIntegrais48h, 'Com 48 horas, deve ter no máximo 2 cotas integrais');
 
         // Teste com 72 horas (3 cotas) - limite = floor(72/24) = 3
-        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade);
+        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade, 10010010001);
         for ($i = 1; $i <= 5; $i++) {
             $bombeiro = new Bombeiro("Bombeiro Integral $i", str_pad((string)$i, 11, '0', STR_PAD_LEFT), false);
             $bombeiro->setCidadeOrigem(CbmscConstants::CIDADE_VIDEIRA);

--- a/skeleton/tests/Service/DistribuicaoTurnosTest.php
+++ b/skeleton/tests/Service/DistribuicaoTurnosTest.php
@@ -22,7 +22,7 @@ class DistribuicaoTurnosTest extends TestCase
         $this->calculadorDeAntiguidade->method('getAntiguidade')
             ->willReturn(50); // Retorna uma antiguidade padrão de 50
 
-        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade);
+        $this->calculador = new CalculadorDePontos($this->calculadorDeAntiguidade, 10010010001);
     }
 
     /**


### PR DESCRIPTION
- Change CPF_DO_QUERUBIN from constant to static method that reads from CPF_DO_QUERUBIN env var
- Simplify Querubim check to only use CPF comparison, removing redundant name check
- Update all test usages to call the new method
- Add .phpunit.cache to .gitignore